### PR TITLE
update docs for webpack 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ module.exports = {
     module: {
         loaders: [{
             test: /(\.tpl|\.html)$/,
-            loader: 'lodash-template-webpack',
+            loader: 'lodash-template-webpack-loader',
         }],
     },
     lodashTemplateLoader: {
@@ -188,7 +188,7 @@ module.exports = {
     module: {
         loaders: [{
             test: /(\.tpl|\.html)$/,
-            loader: 'lodash-template-webpack',
+            loader: 'lodash-template-webpack-loader',
         }, {
             test: /(\.gif|\.png|\.jpg)$/,
             loader: 'url-loader', // or 'file-loader'


### PR DESCRIPTION
Thanks for this @kmck! Webpack 4 evidently disallows the omission of `loader` from loader declarations (e.g. 'lodash-template-webpack' must now be 'lodash-template-webpack-loader'), so I added the suffix back in to the readme examples for those of us living on the edge...